### PR TITLE
0.0.7 - Public api security patch, safety additions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,42 @@
+name: Benchmarks
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13", "3.14", "3.x"]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: "Set up Python"
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install test dependencies
+        run: uv sync --group test
+
+      - name: Install project
+        run: uv pip install -e .
+
+      - name: Run benchmark suite
+        run: |
+          mkdir -p .benchmarks
+          uv run pytest tests/benchmarks --benchmark-only --benchmark-json=.benchmarks/output.json
+
+      - name: Upload benchmark artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: .benchmarks/output.json

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -38,5 +38,5 @@ jobs:
       - name: Upload benchmark artifact
         uses: actions/upload-artifact@v4
         with:
-          name: benchmark-results
+          name: benchmark-results-py${{ matrix.python-version }}
           path: .benchmarks/output.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dev dependencies
-        run: uv sync --all-extras
+        run: uv sync --group test
 
       - name: Install project
         run: uv pip install -e .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install dev dependencies
+      - name: Install test dependencies
         run: uv sync --group test
 
       - name: Install project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: uv pip install -e .
 
       - name: Run tests
-        run: uv run pytest --cov=plotsrv --cov-report=xml
+        run: uv run pytest --benchmark-skip --cov=plotsrv --cov-report=xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/anees-hill/plotsrv/main/src/plotsrv/static/plotsrv_icon_logo.png" width="200"><br>
-  <img src="https://raw.githubusercontent.com/anees-hill/plotsrv/main/src/plotsrv/static/plotsrv_title_logo.png" width="520">
+  <img src="https://raw.githubusercontent.com/anees-hill/plotsrv/main/src/plotsrv/static/plotsrv_icon_logo.png" width="150"><br>
+  <img src="https://raw.githubusercontent.com/anees-hill/plotsrv/main/src/plotsrv/static/plotsrv_title_logo.png" width="300">
 </p>
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plotsrv"
-version = "0.0.6"
+version = "0.0.7"
 description = "Cheap observability for Python processes"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
 [dependency-groups]
 test = [
     "pytest~=9.0.1",
+    "pytest-benchmark~=5.2.3",
     "pytest-cov~=7.0.0",
     "httpx~=0.28.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,25 +16,26 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "bleach>=6.3.0",
-    "fastapi>=0.121.3",
-    "markdown>=3.10.2",
-    "matplotlib>=3.10.7",
-    "plotnine>=0.15.1",
-    "pyyaml>=6.0.3",
-    "requests>=2.32.5",
-    "uvicorn>=0.38.0",
+    "bleach~=6.3.0",
+    "fastapi~=0.121.3",
+    "markdown~=3.10.2",
+    "matplotlib~=3.10.7",
+    "plotnine~=0.15.1",
+    "pyyaml~=6.0.3",
+    "requests~=2.32.5",
+    "uvicorn~=0.38.0",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
+test = [
+    "pytest~=9.0.1",
+    "pytest-cov~=7.0.0",
+    "httpx~=0.28.1",
+]
 dev = [
-    "seaborn>=0.13.2",
-    "polars-lts-cpu>=1.33.1",
-    "pyarrow>=20.0.0",
-    "pytest>=9.0.1",
-    "pytest-cov>=7.0.0",
-    "httpx>=0.28.1",
-    "psutil>=7.2.2",
+    "seaborn~=0.13.2",
+    "polars-lts-cpu~=1.33.1",
+    "pyarrow~=20.0.0",
 ]
 
 [project.scripts]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers =
     integration: tests that start the server and hit HTTP endpoints
+    benchmark: performance benchmark tests

--- a/src/plotsrv/app.py
+++ b/src/plotsrv/app.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import base64
+import shutil
 import ipaddress
 import time
 from pathlib import Path
@@ -40,27 +41,41 @@ STATIC_DIR = Path(__file__).resolve().parent / "static"
 if STATIC_DIR.exists():
     app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
 
+_ASSETS_CACHE_DIR = STATIC_DIR / "_runtime_assets"
+
 
 def _ensure_assets_mount() -> None:
     """
-    Mount /assets based on current runtime UI settings.
-
-    Lazy- so CLI args (--config/--name) are already
-    applied before we resolve paths.
+    Mount /assets using a dedicated cache directory containing only explicitly
+    configured asset files (for example logo/favicon), not their whole parents.
     """
     ui = get_ui_settings()
-    assets_dir = ui.assets_dir
-    if assets_dir is None or not assets_dir.exists():
+
+    asset_files: list[Path] = []
+    if ui.assets_dir is not None:
+        # backwards compatibility: if assets_dir is actually a file, use it
+        if ui.assets_dir.exists() and ui.assets_dir.is_file():
+            asset_files.append(ui.assets_dir)
+
+    # Rebuild cache dir
+    if not asset_files:
         return
+
+    _ASSETS_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+    for src in asset_files:
+        dst = _ASSETS_CACHE_DIR / src.name
+        if not dst.exists() or src.stat().st_mtime > dst.stat().st_mtime:
+            shutil.copy2(src, dst)
 
     existing = app.router.routes
     for route in existing:
         if getattr(route, "path", None) == "/assets":
             current_dir = getattr(getattr(route, "app", None), "directory", None)
-            if current_dir == str(assets_dir):
+            if current_dir == str(_ASSETS_CACHE_DIR):
                 return
 
-    app.mount("/assets", StaticFiles(directory=str(assets_dir)), name="assets")
+    app.mount("/assets", StaticFiles(directory=str(_ASSETS_CACHE_DIR)), name="assets")
 
 
 def _container_item_count(obj: Any) -> int:

--- a/src/plotsrv/app.py
+++ b/src/plotsrv/app.py
@@ -2,25 +2,37 @@
 from __future__ import annotations
 
 import base64
+import ipaddress
 import time
 from pathlib import Path
 from typing import Any
 
 import pandas as pd
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import Response, HTMLResponse
 from fastapi.staticfiles import StaticFiles
 
 from . import store, config
 from . import html as html_mod
-from .backends import df_to_rich_sample
 from .ui_config import get_ui_settings
 from .renderers import register_default_renderers
 from .renderers.registry import render_any
 from .storage.worker import enqueue_snapshot
 from .storage.backend import list_snapshots, load_snapshot
 
-app = FastAPI()
+
+def _build_app() -> FastAPI:
+    docs_enabled = config.get_docs_enabled()
+    openapi_enabled = config.get_openapi_enabled()
+
+    return FastAPI(
+        docs_url="/docs" if docs_enabled else None,
+        redoc_url="/redoc" if docs_enabled else None,
+        openapi_url="/openapi.json" if openapi_enabled else None,
+    )
+
+
+app = _build_app()
 register_default_renderers()
 
 # Static files shipped inside plotsrv package (logo, etc.)
@@ -49,6 +61,28 @@ def _ensure_assets_mount() -> None:
                 return
 
     app.mount("/assets", StaticFiles(directory=str(assets_dir)), name="assets")
+
+
+def _client_ip(request: Request) -> str | None:
+    client = request.client
+    if client is None:
+        return None
+    return client.host
+
+
+def _is_loopback_ip(value: str | None) -> bool:
+    if not value:
+        return False
+    try:
+        return ipaddress.ip_address(value).is_loopback
+    except ValueError:
+        return False
+
+
+def require_local_request(request: Request) -> None:
+    host = _client_ip(request)
+    if not _is_loopback_ip(host):
+        raise HTTPException(status_code=403, detail="Local access only")
 
 
 def _storage_root() -> Path:
@@ -127,10 +161,10 @@ def _render_table_snapshot_html(*, view_id: str, snapshot_id: str) -> dict[str, 
 
 
 @app.get("/status")
-def status(view: str | None = None) -> dict[str, object]:
-    """
-    Status for a single view (default: active view).
-    """
+def status(request: Request, view: str | None = None) -> dict[str, object]:
+    if config.get_internal_read_local_only():
+        require_local_request(request)
+
     vid = view or store.get_active_view_id()
     s = store.get_status(view_id=vid)
     s.update(store.get_service_info())
@@ -140,10 +174,10 @@ def status(view: str | None = None) -> dict[str, object]:
 
 
 @app.get("/history")
-def get_history(view: str | None = None) -> dict[str, Any]:
-    """
-    List stored snapshots for a view, newest first.
-    """
+def get_history(request: Request, view: str | None = None) -> dict[str, Any]:
+    if config.get_internal_read_local_only():
+        require_local_request(request)
+
     vid = view or store.get_active_view_id()
     snaps = list_snapshots(root_dir=_storage_root(), view_id=vid)
 
@@ -315,7 +349,7 @@ def export_table(
 
 
 @app.post("/publish")
-def publish(payload: dict[str, Any]) -> dict[str, Any]:
+def publish(request: Request, payload: dict[str, Any]) -> dict[str, Any]:
     """
     Publish a plot or table into a specific view.
 
@@ -337,6 +371,9 @@ def publish(payload: dict[str, Any]) -> dict[str, Any]:
         "force": false                # optional bypass throttling
       }
     """
+    if config.get_control_local_only():
+        require_local_request(request)
+
     kind = str(payload.get("kind") or "").strip().lower()
     if kind not in ("plot", "table", "artifact"):
         raise HTTPException(
@@ -502,11 +539,9 @@ def index(view: str | None = None) -> HTMLResponse:
     Main HTML viewer.
 
     Supports: /?view=<view_id>
+    This is request-local only and does not mutate global active view.
     """
-    if view:
-        store.set_active_view(view)
-
-    active_view = store.get_active_view_id()
+    active_view = view or store.get_active_view_id()
     kind = store.get_kind(active_view)
 
     if store.has_artifact(view_id=active_view):
@@ -611,7 +646,10 @@ def get_artifact(
 
 
 @app.get("/views")
-def get_views() -> list[dict[str, Any]]:
+def get_views(request: Request) -> list[dict[str, Any]]:
+    if config.get_internal_read_local_only():
+        require_local_request(request)
+
     return [
         {
             "view_id": v.view_id,

--- a/src/plotsrv/app.py
+++ b/src/plotsrv/app.py
@@ -63,6 +63,50 @@ def _ensure_assets_mount() -> None:
     app.mount("/assets", StaticFiles(directory=str(assets_dir)), name="assets")
 
 
+def _container_item_count(obj: Any) -> int:
+    if isinstance(obj, dict):
+        n = len(obj)
+        for v in obj.values():
+            n += _container_item_count(v)
+        return n
+    if isinstance(obj, (list, tuple, set)):
+        n = len(obj)
+        for v in obj:
+            n += _container_item_count(v)
+        return n
+    return 0
+
+
+def _validate_artifact_size(obj: Any) -> None:
+    max_text = config.get_publish_max_artifact_text_chars()
+    max_items = config.get_publish_max_json_container_items()
+
+    if isinstance(obj, str):
+        if len(obj) > max_text:
+            raise HTTPException(
+                status_code=413,
+                detail=f"publish: artifact text too large (>{max_text} chars)",
+            )
+        return
+
+    if isinstance(obj, (dict, list, tuple, set)):
+        item_count = _container_item_count(obj)
+        if item_count > max_items:
+            raise HTTPException(
+                status_code=413,
+                detail=f"publish: artifact JSON/container too large (>{max_items} items)",
+            )
+        return
+
+    # repr-like fallback
+    s = repr(obj)
+    if len(s) > max_text:
+        raise HTTPException(
+            status_code=413,
+            detail=f"publish: artifact representation too large (>{max_text} chars)",
+        )
+
+
 def _client_ip(request: Request) -> str | None:
     client = request.client
     if client is None:
@@ -432,6 +476,12 @@ def publish(request: Request, payload: dict[str, Any]) -> dict[str, Any]:
 
         try:
             png_bytes = base64.b64decode(b64.encode("utf-8"))
+            max_plot_bytes = config.get_publish_max_plot_bytes()
+            if len(png_bytes) > max_plot_bytes:
+                raise HTTPException(
+                    status_code=413,
+                    detail=f"publish: decoded plot too large (>{max_plot_bytes} bytes)",
+                )
         except Exception:
             raise HTTPException(
                 status_code=422, detail="publish: plot_png_b64 was not valid base64"
@@ -455,6 +505,8 @@ def publish(request: Request, payload: dict[str, Any]) -> dict[str, Any]:
     elif kind == "artifact":
         artifact_kind = str(payload.get("artifact_kind") or "python").strip().lower()
         artifact_obj = payload.get("artifact")
+
+        _validate_artifact_size(artifact_obj)
 
         store.set_artifact(
             obj=artifact_obj,
@@ -492,6 +544,28 @@ def publish(request: Request, payload: dict[str, Any]) -> dict[str, Any]:
                 status_code=422,
                 detail="publish: table must include columns(list) and rows(list)",
             )
+
+        max_rows = config.get_publish_max_table_rows()
+        max_cols = config.get_publish_max_table_columns()
+
+        if len(cols) > max_cols:
+            raise HTTPException(
+                status_code=413,
+                detail=f"publish: table has too many columns (>{max_cols})",
+            )
+
+        if len(rows) > max_rows:
+            raise HTTPException(
+                status_code=413,
+                detail=f"publish: table has too many rows (>{max_rows})",
+            )
+
+        for i, row in enumerate(rows[:50]):
+            if isinstance(row, dict) and len(row) > max_cols:
+                raise HTTPException(
+                    status_code=413,
+                    detail=f"publish: table row {i} has too many fields (>{max_cols})",
+                )
 
         total_rows = table.get("total_rows")
         returned_rows = table.get("returned_rows")

--- a/src/plotsrv/config.py
+++ b/src/plotsrv/config.py
@@ -65,6 +65,13 @@ _DEFAULTS: dict[str, Any] = {
         "overdue_after": None,
         "views": {},
     },
+    "publish-limits": {
+        "max_plot_bytes": 5 * 1024 * 1024,
+        "max_table_rows": 5000,
+        "max_table_columns": 200,
+        "max_artifact_text_chars": 200_000,
+        "max_json_container_items": 20_000,
+    },
 }
 
 _MAX_TABLE_ROWS_INF: int = 1_000_000_000
@@ -593,3 +600,31 @@ def get_control_local_only() -> bool:
 def get_internal_read_local_only() -> bool:
     sec = _merged_section("security-settings")
     return _as_bool(sec.get("internal_read_local_only"), True)
+
+
+# ---- Publish limits -----------------------------------------------------------
+
+
+def get_publish_max_plot_bytes() -> int:
+    sec = _merged_section("publish-limits")
+    return _as_int_or_inf(sec.get("max_plot_bytes"), 5 * 1024 * 1024, min_value=1)
+
+
+def get_publish_max_table_rows() -> int:
+    sec = _merged_section("publish-limits")
+    return _as_int_or_inf(sec.get("max_table_rows"), 5000, min_value=1)
+
+
+def get_publish_max_table_columns() -> int:
+    sec = _merged_section("publish-limits")
+    return _as_int_or_inf(sec.get("max_table_columns"), 200, min_value=1)
+
+
+def get_publish_max_artifact_text_chars() -> int:
+    sec = _merged_section("publish-limits")
+    return _as_int_or_inf(sec.get("max_artifact_text_chars"), 200_000, min_value=1)
+
+
+def get_publish_max_json_container_items() -> int:
+    sec = _merged_section("publish-limits")
+    return _as_int_or_inf(sec.get("max_json_container_items"), 20_000, min_value=1)

--- a/src/plotsrv/config.py
+++ b/src/plotsrv/config.py
@@ -31,10 +31,17 @@ _DEFAULTS: dict[str, Any] = {
         "plot_pad_inches": 0.10,
     },
     "artifact-render-settings": {
-        "html_sanitize": False,
-        "html_sandbox": "allow-forms allow-modals allow-popups allow-downloads",
+        "html_sanitize": True,
+        "html_sandbox": "",
         "markdown_sanitize": True,
-        "markdown_sandbox": "allow-forms allow-modals allow-popups allow-downloads",
+        "markdown_sandbox": "",
+    },
+    "security-settings": {
+        "docs_enabled": False,
+        "openapi_enabled": False,
+        "shutdown_enabled": False,
+        "control_local_only": True,
+        "internal_read_local_only": True,
     },
     "view-order-settings": {},
     "truncation": {
@@ -558,3 +565,31 @@ def get_freshness_error_after_s(view_id: str | None = None) -> int | None:
     Prefer get_freshness_overdue_after_s().
     """
     return get_freshness_overdue_after_s(view_id)
+
+
+# ---- Security settings --------------------------------------------------------
+
+
+def get_docs_enabled() -> bool:
+    sec = _merged_section("security-settings")
+    return _as_bool(sec.get("docs_enabled"), False)
+
+
+def get_openapi_enabled() -> bool:
+    sec = _merged_section("security-settings")
+    return _as_bool(sec.get("openapi_enabled"), False)
+
+
+def get_shutdown_enabled() -> bool:
+    sec = _merged_section("security-settings")
+    return _as_bool(sec.get("shutdown_enabled"), False)
+
+
+def get_control_local_only() -> bool:
+    sec = _merged_section("security-settings")
+    return _as_bool(sec.get("control_local_only"), True)
+
+
+def get_internal_read_local_only() -> bool:
+    sec = _merged_section("security-settings")
+    return _as_bool(sec.get("internal_read_local_only"), True)

--- a/src/plotsrv/server.py
+++ b/src/plotsrv/server.py
@@ -19,9 +19,9 @@ except Exception:  # pragma: no cover
     pl = None  # type: ignore[assignment]
 
 import uvicorn
-from fastapi import BackgroundTasks
+from fastapi import BackgroundTasks, HTTPException
 
-from .app import app
+from .app import app, require_local_request
 from .backends import fig_to_png_bytes, df_to_html_simple
 from . import store, config
 from .storage.worker import stop_storage_worker
@@ -39,7 +39,7 @@ _SERVER_THREAD: threading.Thread | None = None
 _SERVER: uvicorn.Server | None = None
 _SERVER_RUNNING: bool = False
 
-_DEFAULT_HOST: str = "0.0.0.0"
+_DEFAULT_HOST: str = "127.0.0.1"
 _DEFAULT_PORT: int = 8000
 _CURRENT_HOST: str = _DEFAULT_HOST
 _CURRENT_PORT: int = _DEFAULT_PORT
@@ -225,7 +225,7 @@ def _unpatch_matplotlib_show() -> None:
 
 def start_server(
     *,
-    host: str = "0.0.0.0",
+    host: str = "127.0.0.1",
     port: int = 8000,
     auto_on_show: bool = True,
     quiet: bool = True,

--- a/src/plotsrv/server.py
+++ b/src/plotsrv/server.py
@@ -268,7 +268,7 @@ def stop_server(*, join: bool = False, timeout: float = 10.0) -> None:
 @contextmanager
 def plot_session(
     *,
-    host: str = "0.0.0.0",
+    host: str = "127.0.0.1",
     port: int = 8000,
     auto_on_show: bool = True,
     quiet: bool = True,

--- a/src/plotsrv/server.py
+++ b/src/plotsrv/server.py
@@ -293,13 +293,17 @@ refresh_plot_server = refresh_view
 
 
 @app.post("/shutdown")
-def shutdown(background_tasks: BackgroundTasks) -> dict[str, str]:
+def shutdown(background_tasks: BackgroundTasks, request) -> dict[str, str]:
     """
     Shutdown endpoint triggered from the browser.
 
-    - If a CLI RunnerService is running, request it to stop cleanly.
-    - Otherwise just stop the uvicorn viewer thread.
+    Disabled by default.
     """
+    if not config.get_shutdown_enabled():
+        raise HTTPException(status_code=404, detail="Not found")
+
+    if config.get_control_local_only():
+        require_local_request(request)
 
     def _do_shutdown() -> None:
         stopped_service = store.request_service_stop()

--- a/src/plotsrv/ui_config.py
+++ b/src/plotsrv/ui_config.py
@@ -103,7 +103,7 @@ def load_ui_settings() -> UISettings:
     header_fill = DEFAULT_HEADER_FILL
 
     show_view_selector = True
-    terminate_process_option = True
+    terminate_process_option = False
     auto_refresh_option = True
     export_image = True
     export_table = True

--- a/src/plotsrv/ui_config.py
+++ b/src/plotsrv/ui_config.py
@@ -85,7 +85,7 @@ def _resolve_asset_url(raw: str, *, default_url: str) -> tuple[str, Path | None]
     base = settings.get_runtime_config_dir() or Path.cwd()
     p = (base / raw2).expanduser().resolve()
     if p.exists() and p.is_file():
-        return f"/assets/{p.name}", p.parent
+        return f"/assets/{p.name}", p
 
     return default_url, None
 

--- a/tests/benchmarks/test_bench_discovery.py
+++ b/tests/benchmarks/test_bench_discovery.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from plotsrv.discovery import discover_views
+
+
+def _write_file(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _make_project(root: Path, *, n_files: int, views_per_file: int) -> None:
+    dec_import = "from plotsrv.decorators import plot, table\n\n"
+
+    for i in range(n_files):
+        parts: list[str] = [dec_import]
+        for j in range(views_per_file):
+            parts.append(
+                f"""
+@plot(label="plot_{i}_{j}", section="sec_{i % 5}")
+def plot_fn_{i}_{j}():
+    return None
+
+@table(label="table_{i}_{j}", section="sec_{i % 5}")
+def table_fn_{i}_{j}():
+    return None
+""".strip()
+            )
+            parts.append("\n\n")
+        _write_file(root / f"pkg/mod_{i}.py", "".join(parts))
+
+
+def test_benchmark_discover_views_small(benchmark, tmp_path: Path) -> None:
+    project_root = tmp_path / "small_project"
+    _make_project(project_root, n_files=10, views_per_file=3)
+
+    result = benchmark(discover_views, project_root)
+
+    assert len(result) == 60
+
+
+def test_benchmark_discover_views_medium(benchmark, tmp_path: Path) -> None:
+    project_root = tmp_path / "medium_project"
+    _make_project(project_root, n_files=40, views_per_file=5)
+
+    result = benchmark(discover_views, project_root)
+
+    assert len(result) == 400

--- a/tests/benchmarks/test_bench_renderers.py
+++ b/tests/benchmarks/test_bench_renderers.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from plotsrv.renderers.registry import render_any
+
+
+def _make_large_markdown() -> str:
+    blocks = []
+    for i in range(300):
+        blocks.append(
+            f"# Heading {i}\n\n"
+            f"Some paragraph text for section {i}.\n\n"
+            f"- item one\n- item two\n- item three\n\n"
+            f"```python\nprint('hello {i}')\n```\n"
+        )
+    return "\n".join(blocks)
+
+
+def _make_large_html() -> str:
+    parts = ["<div>"]
+    for i in range(500):
+        parts.append(
+            f"<section><h2>Section {i}</h2><p>This is some html content {i}.</p></section>"
+        )
+    parts.append("</div>")
+    return "".join(parts)
+
+
+def _make_large_json() -> dict[str, object]:
+    return {
+        "items": [
+            {
+                "id": i,
+                "name": f"item_{i}",
+                "values": list(range(20)),
+                "meta": {
+                    "group": i % 10,
+                    "flag": i % 2 == 0,
+                    "text": "x" * 200,
+                },
+            }
+            for i in range(500)
+        ],
+        "summary": {
+            "count": 500,
+            "description": "benchmark payload",
+        },
+    }
+
+
+def _make_traceback_payload() -> dict[str, object]:
+    frames = []
+    for i in range(40):
+        frames.append(
+            {
+                "filename": f"/tmp/module_{i}.py",
+                "lineno": 100 + i,
+                "function": f"func_{i}",
+                "line": f"raise ValueError('bad value {i}')",
+                "context_before": [f"line before {j}" for j in range(3)],
+                "context_after": [f"line after {j}" for j in range(3)],
+            }
+        )
+    return {
+        "type": "traceback",
+        "exc_type": "ValueError",
+        "exc_msg": "Something went wrong",
+        "frames": frames,
+    }
+
+
+def test_benchmark_render_markdown(benchmark) -> None:
+    payload = _make_large_markdown()
+    result = benchmark(
+        lambda: render_any(payload, view_id="bench", kind_hint="markdown")
+    )
+
+    assert result.kind == "markdown"
+
+
+def test_benchmark_render_html(benchmark) -> None:
+    payload = _make_large_html()
+    result = benchmark(lambda: render_any(payload, view_id="bench", kind_hint="html"))
+
+    assert result.kind == "html"
+
+
+def test_benchmark_render_json_tree(benchmark) -> None:
+    payload = _make_large_json()
+    result = benchmark(lambda: render_any(payload, view_id="bench", kind_hint="json"))
+
+    assert result.kind == "json"
+
+
+def test_benchmark_render_traceback(benchmark) -> None:
+    payload = _make_traceback_payload()
+    result = benchmark(
+        lambda: render_any(payload, view_id="bench", kind_hint="traceback")
+    )
+
+    assert result.kind == "traceback"
+
+
+def test_benchmark_render_text(benchmark) -> None:
+    payload = "\n".join(f"log line {i}" for i in range(5000))
+    result = benchmark(lambda: render_any(payload, view_id="bench", kind_hint="text"))
+
+    assert result.kind == "text"

--- a/tests/benchmarks/test_bench_routes.py
+++ b/tests/benchmarks/test_bench_routes.py
@@ -9,9 +9,11 @@ from plotsrv import config, store
 
 
 @pytest.fixture(autouse=True)
-def reset_state() -> None:
+def reset_state(monkeypatch: pytest.MonkeyPatch) -> None:
     store.reset()
     config.set_table_view_mode("simple")
+    monkeypatch.setattr(config, "get_control_local_only", lambda: False)
+    monkeypatch.setattr(config, "get_internal_read_local_only", lambda: False)
     yield
     store.reset()
     config.set_table_view_mode("simple")

--- a/tests/benchmarks/test_bench_routes.py
+++ b/tests/benchmarks/test_bench_routes.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+from fastapi.testclient import TestClient
+
+from plotsrv.app import app
+from plotsrv import config, store
+
+
+@pytest.fixture(autouse=True)
+def reset_state() -> None:
+    store.reset()
+    config.set_table_view_mode("simple")
+    yield
+    store.reset()
+    config.set_table_view_mode("simple")
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def _make_medium_df(rows: int = 1000, cols: int = 10) -> pd.DataFrame:
+    return pd.DataFrame(
+        {f"col_{j}": [f"value_{i}_{j}" for i in range(rows)] for j in range(cols)}
+    )
+
+
+def test_benchmark_status_route(client: TestClient, benchmark) -> None:
+    resp = benchmark(lambda: client.get("/status"))
+    assert resp.status_code == 200
+
+
+def test_benchmark_views_route(client: TestClient, benchmark) -> None:
+    for i in range(100):
+        store.register_view(section="sec", label=f"label_{i}", kind="none")
+
+    resp = benchmark(lambda: client.get("/views"))
+    assert resp.status_code == 200
+
+
+def test_benchmark_table_data_route(client: TestClient, benchmark) -> None:
+    df = _make_medium_df(rows=1000, cols=12)
+    store.set_table(df, html_simple="<table>dummy</table>")
+
+    resp = benchmark(lambda: client.get("/table/data?limit=500"))
+    assert resp.status_code == 200
+
+
+def test_benchmark_artifact_route_json(client: TestClient, benchmark) -> None:
+    payload = {
+        "items": [
+            {"id": i, "name": f"name_{i}", "values": list(range(10))}
+            for i in range(400)
+        ]
+    }
+    store.set_artifact(obj=payload, kind="json")
+
+    resp = benchmark(lambda: client.get("/artifact"))
+    assert resp.status_code == 200
+
+
+def test_benchmark_artifact_route_markdown(client: TestClient, benchmark) -> None:
+    payload = "\n".join(
+        f"## Section {i}\n\nSome text here.\n\n- a\n- b\n- c" for i in range(250)
+    )
+    store.set_artifact(obj=payload, kind="markdown")
+
+    resp = benchmark(lambda: client.get("/artifact"))
+    assert resp.status_code == 200

--- a/tests/test_app_more.py
+++ b/tests/test_app_more.py
@@ -11,9 +11,11 @@ from plotsrv import store, config
 
 
 @pytest.fixture(autouse=True)
-def reset_state() -> None:
+def reset_state(monkeypatch: pytest.MonkeyPatch) -> None:
     store.reset()
     config.set_table_view_mode("simple")
+    monkeypatch.setattr(config, "get_control_local_only", lambda: False)
+    monkeypatch.setattr(config, "get_internal_read_local_only", lambda: False)
     yield
     store.reset()
     config.set_table_view_mode("simple")

--- a/tests/test_app_routes.py
+++ b/tests/test_app_routes.py
@@ -12,9 +12,11 @@ from plotsrv import store, config
 
 
 @pytest.fixture(autouse=True)
-def reset_state() -> None:
+def reset_state(monkeypatch: pytest.MonkeyPatch) -> None:
     store.reset()
     config.set_table_view_mode("simple")
+    monkeypatch.setattr(config, "get_control_local_only", lambda: False)
+    monkeypatch.setattr(config, "get_internal_read_local_only", lambda: False)
     yield
     store.reset()
     config.set_table_view_mode("simple")

--- a/tests/test_app_storage_and_snapshots.py
+++ b/tests/test_app_storage_and_snapshots.py
@@ -18,6 +18,8 @@ def reset_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     store.reset()
     config.set_table_view_mode("simple")
     monkeypatch.setattr(app_mod.config, "get_storage_root_dir", lambda: tmp_path)
+    monkeypatch.setattr(app_mod.config, "get_control_local_only", lambda: False)
+    monkeypatch.setattr(app_mod.config, "get_internal_read_local_only", lambda: False)
     yield
     store.reset()
     config.set_table_view_mode("simple")
@@ -352,7 +354,7 @@ def test_publish_sets_active_view_when_current_active_unknown(
     assert store.get_active_view_id() == "ops:log"
 
 
-def test_index_with_view_param_sets_active_view_and_artifact_kind(
+def test_index_with_view_param_is_request_local_and_does_not_set_active_view(
     client: TestClient,
 ) -> None:
     vid = store.register_view(section="ops", label="log", kind="none")
@@ -360,9 +362,11 @@ def test_index_with_view_param_sets_active_view_and_artifact_kind(
         obj="hello", kind="text", section="ops", label="log", view_id=vid
     )
 
+    store.set_active_view("default")
+
     r = client.get(f"/?view={vid}")
     assert r.status_code == 200
-    assert store.get_active_view_id() == vid
+    assert store.get_active_view_id() == "default"
 
 
 def test_index_table_simple_lookuperror_falls_back_to_none(

--- a/tests/test_renderers_html_markdown.py
+++ b/tests/test_renderers_html_markdown.py
@@ -118,7 +118,7 @@ def test_html_renderer_default_mode_uses_config_default() -> None:
 
     assert rr.kind == "html"
     assert rr.meta
-    assert rr.meta["mode"] == "unsafe_iframe"
+    assert rr.meta["mode"] == "sanitized"
 
 
 # ----------------------------

--- a/tests/test_ui_config_more.py
+++ b/tests/test_ui_config_more.py
@@ -79,7 +79,7 @@ ui-settings:
     s = ui.load_ui_settings()
     assert s.logo_url == f"/assets/{logo.name}"
     assert s.favicon_url == f"/assets/{favicon.name}"
-    assert s.assets_dir == tmp_path.resolve()
+    assert s.assets_dir == logo.resolve()
 
 
 def test_load_ui_settings_bad_logo_path_falls_back_to_default(

--- a/uv.lock
+++ b/uv.lock
@@ -917,6 +917,7 @@ dev = [
 test = [
     { name = "httpx" },
     { name = "pytest" },
+    { name = "pytest-benchmark" },
     { name = "pytest-cov" },
 ]
 
@@ -941,6 +942,7 @@ dev = [
 test = [
     { name = "httpx", specifier = "~=0.28.1" },
     { name = "pytest", specifier = "~=9.0.1" },
+    { name = "pytest-benchmark", specifier = "~=5.2.3" },
     { name = "pytest-cov", specifier = "~=7.0.0" },
 ]
 
@@ -965,6 +967,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/54/31/0474c14dce2c0507bea40069daafb848980ba7c351ad991908e51ac895fb/polars_lts_cpu-1.33.1-cp39-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:64574c784380b37167b3db3a7cfdb9839cd308e89b8818859d2ffb34a9c896b2", size = 36685020, upload-time = "2025-09-09T08:37:15.597Z" },
     { url = "https://files.pythonhosted.org/packages/d4/0a/5ebba9b145388ffbbd09fa84ac3cd7d336b922e34256b1417abf0a1c2fb9/polars_lts_cpu-1.33.1-cp39-abi3-win_amd64.whl", hash = "sha256:6b849e0e1485acb8ac39bf13356d280ea7c924c2b41cd548ea6e4d102d70be77", size = 39191650, upload-time = "2025-09-09T08:37:19.541Z" },
     { url = "https://files.pythonhosted.org/packages/ce/ad/bf3db68d30ac798ca31c80624709a0c03aa890e2e20e5ca987d7e55fcfc2/polars_lts_cpu-1.33.1-cp39-abi3-win_arm64.whl", hash = "sha256:c99ab56b059cee6bcabe9fb89e97f5813be1012a2251bf77f76e15c2d1cba934", size = 35445244, upload-time = "2025-09-09T08:37:22.97Z" },
+]
+
+[[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
 ]
 
 [[package]]
@@ -1155,6 +1166,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/07/56/f013048ac4bc4c1d9be45afd4ab209ea62822fb1598f40687e6bf45dcea4/pytest-9.0.1.tar.gz", hash = "sha256:3e9c069ea73583e255c3b21cf46b8d3c56f6e3a1a8f6da94ccb0fcf57b9d73c8", size = 1564125, upload-time = "2025-11-12T13:05:09.333Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/8b/6300fb80f858cda1c51ffa17075df5d846757081d11ab4aa35cef9e6258b/pytest-9.0.1-py3-none-any.whl", hash = "sha256:67be0030d194df2dfa7b556f2e56fb3c3315bd5c8822c6951162b92b32ce7dad", size = 373668, upload-time = "2025-11-12T13:05:07.379Z" },
+]
+
+[[package]]
+name = "pytest-benchmark"
+version = "5.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "py-cpuinfo" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/34/9f732b76456d64faffbef6232f1f9dbec7a7c4999ff46282fa418bd1af66/pytest_benchmark-5.2.3.tar.gz", hash = "sha256:deb7317998a23c650fd4ff76e1230066a76cb45dcece0aca5607143c619e7779", size = 341340, upload-time = "2025-11-09T18:48:43.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/29/e756e715a48959f1c0045342088d7ca9762a2f509b945f362a316e9412b7/pytest_benchmark-5.2.3-py3-none-any.whl", hash = "sha256:bc839726ad20e99aaa0d11a127445457b4219bdb9e80a1afc4b51da7f96b0803", size = 45255, upload-time = "2025-11-09T18:48:39.765Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -895,7 +895,7 @@ wheels = [
 
 [[package]]
 name = "plotsrv"
-version = "0.0.4"
+version = "0.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "bleach" },
@@ -908,36 +908,41 @@ dependencies = [
     { name = "uvicorn" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
-    { name = "httpx" },
     { name = "polars-lts-cpu" },
-    { name = "psutil" },
     { name = "pyarrow" },
+    { name = "seaborn" },
+]
+test = [
+    { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "seaborn" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "bleach", specifier = ">=6.3.0" },
-    { name = "fastapi", specifier = ">=0.121.3" },
-    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28.1" },
-    { name = "markdown", specifier = ">=3.10.2" },
-    { name = "matplotlib", specifier = ">=3.10.7" },
-    { name = "plotnine", specifier = ">=0.15.1" },
-    { name = "polars-lts-cpu", marker = "extra == 'dev'", specifier = ">=1.33.1" },
-    { name = "psutil", marker = "extra == 'dev'", specifier = ">=7.2.2" },
-    { name = "pyarrow", marker = "extra == 'dev'", specifier = ">=20.0.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.1" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0.0" },
-    { name = "pyyaml", specifier = ">=6.0.3" },
-    { name = "requests", specifier = ">=2.32.5" },
-    { name = "seaborn", marker = "extra == 'dev'", specifier = ">=0.13.2" },
-    { name = "uvicorn", specifier = ">=0.38.0" },
+    { name = "bleach", specifier = "~=6.3.0" },
+    { name = "fastapi", specifier = "~=0.121.3" },
+    { name = "markdown", specifier = "~=3.10.2" },
+    { name = "matplotlib", specifier = "~=3.10.7" },
+    { name = "plotnine", specifier = "~=0.15.1" },
+    { name = "pyyaml", specifier = "~=6.0.3" },
+    { name = "requests", specifier = "~=2.32.5" },
+    { name = "uvicorn", specifier = "~=0.38.0" },
 ]
-provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "polars-lts-cpu", specifier = "~=1.33.1" },
+    { name = "pyarrow", specifier = "~=20.0.0" },
+    { name = "seaborn", specifier = "~=0.13.2" },
+]
+test = [
+    { name = "httpx", specifier = "~=0.28.1" },
+    { name = "pytest", specifier = "~=9.0.1" },
+    { name = "pytest-cov", specifier = "~=7.0.0" },
+]
 
 [[package]]
 name = "pluggy"
@@ -963,81 +968,47 @@ wheels = [
 ]
 
 [[package]]
-name = "psutil"
-version = "7.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
-    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
-    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
-    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
-    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
-    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
-    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
-    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
-]
-
-[[package]]
 name = "pyarrow"
-version = "22.0.0"
+version = "20.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/30/53/04a7fdc63e6056116c9ddc8b43bc28c12cdd181b85cbeadb79278475f3ae/pyarrow-22.0.0.tar.gz", hash = "sha256:3d600dc583260d845c7d8a6db540339dd883081925da2bd1c5cb808f720b3cd9", size = 1151151, upload-time = "2025-10-24T12:30:00.762Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/ee/a7810cb9f3d6e9238e61d312076a9859bf3668fd21c69744de9532383912/pyarrow-20.0.0.tar.gz", hash = "sha256:febc4a913592573c8d5805091a6c2b5064c8bd6e002131f01061797d91c783c1", size = 1125187, upload-time = "2025-04-27T12:34:23.264Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/b7/18f611a8cdc43417f9394a3ccd3eace2f32183c08b9eddc3d17681819f37/pyarrow-22.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:3e294c5eadfb93d78b0763e859a0c16d4051fc1c5231ae8956d61cb0b5666f5a", size = 34272022, upload-time = "2025-10-24T10:04:28.973Z" },
-    { url = "https://files.pythonhosted.org/packages/26/5c/f259e2526c67eb4b9e511741b19870a02363a47a35edbebc55c3178db22d/pyarrow-22.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:69763ab2445f632d90b504a815a2a033f74332997052b721002298ed6de40f2e", size = 35995834, upload-time = "2025-10-24T10:04:35.467Z" },
-    { url = "https://files.pythonhosted.org/packages/50/8d/281f0f9b9376d4b7f146913b26fac0aa2829cd1ee7e997f53a27411bbb92/pyarrow-22.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:b41f37cabfe2463232684de44bad753d6be08a7a072f6a83447eeaf0e4d2a215", size = 45030348, upload-time = "2025-10-24T10:04:43.366Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/e5/53c0a1c428f0976bf22f513d79c73000926cb00b9c138d8e02daf2102e18/pyarrow-22.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:35ad0f0378c9359b3f297299c3309778bb03b8612f987399a0333a560b43862d", size = 47699480, upload-time = "2025-10-24T10:04:51.486Z" },
-    { url = "https://files.pythonhosted.org/packages/95/e1/9dbe4c465c3365959d183e6345d0a8d1dc5b02ca3f8db4760b3bc834cf25/pyarrow-22.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8382ad21458075c2e66a82a29d650f963ce51c7708c7c0ff313a8c206c4fd5e8", size = 48011148, upload-time = "2025-10-24T10:04:59.585Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/b4/7caf5d21930061444c3cf4fa7535c82faf5263e22ce43af7c2759ceb5b8b/pyarrow-22.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1a812a5b727bc09c3d7ea072c4eebf657c2f7066155506ba31ebf4792f88f016", size = 50276964, upload-time = "2025-10-24T10:05:08.175Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/f3/cec89bd99fa3abf826f14d4e53d3d11340ce6f6af4d14bdcd54cd83b6576/pyarrow-22.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:ec5d40dd494882704fb876c16fa7261a69791e784ae34e6b5992e977bd2e238c", size = 28106517, upload-time = "2025-10-24T10:05:14.314Z" },
-    { url = "https://files.pythonhosted.org/packages/af/63/ba23862d69652f85b615ca14ad14f3bcfc5bf1b99ef3f0cd04ff93fdad5a/pyarrow-22.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:bea79263d55c24a32b0d79c00a1c58bb2ee5f0757ed95656b01c0fb310c5af3d", size = 34211578, upload-time = "2025-10-24T10:05:21.583Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/d0/f9ad86fe809efd2bcc8be32032fa72e8b0d112b01ae56a053006376c5930/pyarrow-22.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:12fe549c9b10ac98c91cf791d2945e878875d95508e1a5d14091a7aaa66d9cf8", size = 35989906, upload-time = "2025-10-24T10:05:29.485Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/a8/f910afcb14630e64d673f15904ec27dd31f1e009b77033c365c84e8c1e1d/pyarrow-22.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:334f900ff08ce0423407af97e6c26ad5d4e3b0763645559ece6fbf3747d6a8f5", size = 45021677, upload-time = "2025-10-24T10:05:38.274Z" },
-    { url = "https://files.pythonhosted.org/packages/13/95/aec81f781c75cd10554dc17a25849c720d54feafb6f7847690478dcf5ef8/pyarrow-22.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:c6c791b09c57ed76a18b03f2631753a4960eefbbca80f846da8baefc6491fcfe", size = 47726315, upload-time = "2025-10-24T10:05:47.314Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/d4/74ac9f7a54cfde12ee42734ea25d5a3c9a45db78f9def949307a92720d37/pyarrow-22.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c3200cb41cdbc65156e5f8c908d739b0dfed57e890329413da2748d1a2cd1a4e", size = 47990906, upload-time = "2025-10-24T10:05:58.254Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/71/fedf2499bf7a95062eafc989ace56572f3343432570e1c54e6599d5b88da/pyarrow-22.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ac93252226cf288753d8b46280f4edf3433bf9508b6977f8dd8526b521a1bbb9", size = 50306783, upload-time = "2025-10-24T10:06:08.08Z" },
-    { url = "https://files.pythonhosted.org/packages/68/ed/b202abd5a5b78f519722f3d29063dda03c114711093c1995a33b8e2e0f4b/pyarrow-22.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:44729980b6c50a5f2bfcc2668d36c569ce17f8b17bccaf470c4313dcbbf13c9d", size = 27972883, upload-time = "2025-10-24T10:06:14.204Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/d6/d0fac16a2963002fc22c8fa75180a838737203d558f0ed3b564c4a54eef5/pyarrow-22.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:e6e95176209257803a8b3d0394f21604e796dadb643d2f7ca21b66c9c0b30c9a", size = 34204629, upload-time = "2025-10-24T10:06:20.274Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/9c/1d6357347fbae062ad3f17082f9ebc29cc733321e892c0d2085f42a2212b/pyarrow-22.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:001ea83a58024818826a9e3f89bf9310a114f7e26dfe404a4c32686f97bd7901", size = 35985783, upload-time = "2025-10-24T10:06:27.301Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/c0/782344c2ce58afbea010150df07e3a2f5fdad299cd631697ae7bd3bac6e3/pyarrow-22.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:ce20fe000754f477c8a9125543f1936ea5b8867c5406757c224d745ed033e691", size = 45020999, upload-time = "2025-10-24T10:06:35.387Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/8b/5362443737a5307a7b67c1017c42cd104213189b4970bf607e05faf9c525/pyarrow-22.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:e0a15757fccb38c410947df156f9749ae4a3c89b2393741a50521f39a8cf202a", size = 47724601, upload-time = "2025-10-24T10:06:43.551Z" },
-    { url = "https://files.pythonhosted.org/packages/69/4d/76e567a4fc2e190ee6072967cb4672b7d9249ac59ae65af2d7e3047afa3b/pyarrow-22.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cedb9dd9358e4ea1d9bce3665ce0797f6adf97ff142c8e25b46ba9cdd508e9b6", size = 48001050, upload-time = "2025-10-24T10:06:52.284Z" },
-    { url = "https://files.pythonhosted.org/packages/01/5e/5653f0535d2a1aef8223cee9d92944cb6bccfee5cf1cd3f462d7cb022790/pyarrow-22.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:252be4a05f9d9185bb8c18e83764ebcfea7185076c07a7a662253af3a8c07941", size = 50307877, upload-time = "2025-10-24T10:07:02.405Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/f8/1d0bd75bf9328a3b826e24a16e5517cd7f9fbf8d34a3184a4566ef5a7f29/pyarrow-22.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:a4893d31e5ef780b6edcaf63122df0f8d321088bb0dee4c8c06eccb1ca28d145", size = 27977099, upload-time = "2025-10-24T10:08:07.259Z" },
-    { url = "https://files.pythonhosted.org/packages/90/81/db56870c997805bf2b0f6eeeb2d68458bf4654652dccdcf1bf7a42d80903/pyarrow-22.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:f7fe3dbe871294ba70d789be16b6e7e52b418311e166e0e3cba9522f0f437fb1", size = 34336685, upload-time = "2025-10-24T10:07:11.47Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/98/0727947f199aba8a120f47dfc229eeb05df15bcd7a6f1b669e9f882afc58/pyarrow-22.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:ba95112d15fd4f1105fb2402c4eab9068f0554435e9b7085924bcfaac2cc306f", size = 36032158, upload-time = "2025-10-24T10:07:18.626Z" },
-    { url = "https://files.pythonhosted.org/packages/96/b4/9babdef9c01720a0785945c7cf550e4acd0ebcd7bdd2e6f0aa7981fa85e2/pyarrow-22.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:c064e28361c05d72eed8e744c9605cbd6d2bb7481a511c74071fd9b24bc65d7d", size = 44892060, upload-time = "2025-10-24T10:07:26.002Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/ca/2f8804edd6279f78a37062d813de3f16f29183874447ef6d1aadbb4efa0f/pyarrow-22.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:6f9762274496c244d951c819348afbcf212714902742225f649cf02823a6a10f", size = 47504395, upload-time = "2025-10-24T10:07:34.09Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/f0/77aa5198fd3943682b2e4faaf179a674f0edea0d55d326d83cb2277d9363/pyarrow-22.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a9d9ffdc2ab696f6b15b4d1f7cec6658e1d788124418cb30030afbae31c64746", size = 48066216, upload-time = "2025-10-24T10:07:43.528Z" },
-    { url = "https://files.pythonhosted.org/packages/79/87/a1937b6e78b2aff18b706d738c9e46ade5bfcf11b294e39c87706a0089ac/pyarrow-22.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:ec1a15968a9d80da01e1d30349b2b0d7cc91e96588ee324ce1b5228175043e95", size = 50288552, upload-time = "2025-10-24T10:07:53.519Z" },
-    { url = "https://files.pythonhosted.org/packages/60/ae/b5a5811e11f25788ccfdaa8f26b6791c9807119dffcf80514505527c384c/pyarrow-22.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:bba208d9c7decf9961998edf5c65e3ea4355d5818dd6cd0f6809bec1afb951cc", size = 28262504, upload-time = "2025-10-24T10:08:00.932Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/b0/0fa4d28a8edb42b0a7144edd20befd04173ac79819547216f8a9f36f9e50/pyarrow-22.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:9bddc2cade6561f6820d4cd73f99a0243532ad506bc510a75a5a65a522b2d74d", size = 34224062, upload-time = "2025-10-24T10:08:14.101Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/a8/7a719076b3c1be0acef56a07220c586f25cd24de0e3f3102b438d18ae5df/pyarrow-22.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e70ff90c64419709d38c8932ea9fe1cc98415c4f87ea8da81719e43f02534bc9", size = 35990057, upload-time = "2025-10-24T10:08:21.842Z" },
-    { url = "https://files.pythonhosted.org/packages/89/3c/359ed54c93b47fb6fe30ed16cdf50e3f0e8b9ccfb11b86218c3619ae50a8/pyarrow-22.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:92843c305330aa94a36e706c16209cd4df274693e777ca47112617db7d0ef3d7", size = 45068002, upload-time = "2025-10-24T10:08:29.034Z" },
-    { url = "https://files.pythonhosted.org/packages/55/fc/4945896cc8638536ee787a3bd6ce7cec8ec9acf452d78ec39ab328efa0a1/pyarrow-22.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:6dda1ddac033d27421c20d7a7943eec60be44e0db4e079f33cc5af3b8280ccde", size = 47737765, upload-time = "2025-10-24T10:08:38.559Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/5e/7cb7edeb2abfaa1f79b5d5eb89432356155c8426f75d3753cbcb9592c0fd/pyarrow-22.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:84378110dd9a6c06323b41b56e129c504d157d1a983ce8f5443761eb5256bafc", size = 48048139, upload-time = "2025-10-24T10:08:46.784Z" },
-    { url = "https://files.pythonhosted.org/packages/88/c6/546baa7c48185f5e9d6e59277c4b19f30f48c94d9dd938c2a80d4d6b067c/pyarrow-22.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:854794239111d2b88b40b6ef92aa478024d1e5074f364033e73e21e3f76b25e0", size = 50314244, upload-time = "2025-10-24T10:08:55.771Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/79/755ff2d145aafec8d347bf18f95e4e81c00127f06d080135dfc86aea417c/pyarrow-22.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:b883fe6fd85adad7932b3271c38ac289c65b7337c2c132e9569f9d3940620730", size = 28757501, upload-time = "2025-10-24T10:09:59.891Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/d2/237d75ac28ced3147912954e3c1a174df43a95f4f88e467809118a8165e0/pyarrow-22.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:7a820d8ae11facf32585507c11f04e3f38343c1e784c9b5a8b1da5c930547fe2", size = 34355506, upload-time = "2025-10-24T10:09:02.953Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/2c/733dfffe6d3069740f98e57ff81007809067d68626c5faef293434d11bd6/pyarrow-22.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:c6ec3675d98915bf1ec8b3c7986422682f7232ea76cad276f4c8abd5b7319b70", size = 36047312, upload-time = "2025-10-24T10:09:10.334Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/2b/29d6e3782dc1f299727462c1543af357a0f2c1d3c160ce199950d9ca51eb/pyarrow-22.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:3e739edd001b04f654b166204fc7a9de896cf6007eaff33409ee9e50ceaff754", size = 45081609, upload-time = "2025-10-24T10:09:18.61Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/42/aa9355ecc05997915af1b7b947a7f66c02dcaa927f3203b87871c114ba10/pyarrow-22.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:7388ac685cab5b279a41dfe0a6ccd99e4dbf322edfb63e02fc0443bf24134e91", size = 47703663, upload-time = "2025-10-24T10:09:27.369Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/62/45abedde480168e83a1de005b7b7043fd553321c1e8c5a9a114425f64842/pyarrow-22.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f633074f36dbc33d5c05b5dc75371e5660f1dbf9c8b1d95669def05e5425989c", size = 48066543, upload-time = "2025-10-24T10:09:34.908Z" },
-    { url = "https://files.pythonhosted.org/packages/84/e9/7878940a5b072e4f3bf998770acafeae13b267f9893af5f6d4ab3904b67e/pyarrow-22.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4c19236ae2402a8663a2c8f21f1870a03cc57f0bef7e4b6eb3238cc82944de80", size = 50288838, upload-time = "2025-10-24T10:09:44.394Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/03/f335d6c52b4a4761bcc83499789a1e2e16d9d201a58c327a9b5cc9a41bd9/pyarrow-22.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0c34fe18094686194f204a3b1787a27456897d8a2d62caf84b61e8dfbc0252ae", size = 29185594, upload-time = "2025-10-24T10:09:53.111Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a2/b7930824181ceadd0c63c1042d01fa4ef63eee233934826a7a2a9af6e463/pyarrow-20.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:24ca380585444cb2a31324c546a9a56abbe87e26069189e14bdba19c86c049f0", size = 30856035, upload-time = "2025-04-27T12:28:40.78Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/18/c765770227d7f5bdfa8a69f64b49194352325c66a5c3bb5e332dfd5867d9/pyarrow-20.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:95b330059ddfdc591a3225f2d272123be26c8fa76e8c9ee1a77aad507361cfdb", size = 32309552, upload-time = "2025-04-27T12:28:47.051Z" },
+    { url = "https://files.pythonhosted.org/packages/44/fb/dfb2dfdd3e488bb14f822d7335653092dde150cffc2da97de6e7500681f9/pyarrow-20.0.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f0fb1041267e9968c6d0d2ce3ff92e3928b243e2b6d11eeb84d9ac547308232", size = 41334704, upload-time = "2025-04-27T12:28:55.064Z" },
+    { url = "https://files.pythonhosted.org/packages/58/0d/08a95878d38808051a953e887332d4a76bc06c6ee04351918ee1155407eb/pyarrow-20.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8ff87cc837601532cc8242d2f7e09b4e02404de1b797aee747dd4ba4bd6313f", size = 42399836, upload-time = "2025-04-27T12:29:02.13Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/cd/efa271234dfe38f0271561086eedcad7bc0f2ddd1efba423916ff0883684/pyarrow-20.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:7a3a5dcf54286e6141d5114522cf31dd67a9e7c9133d150799f30ee302a7a1ab", size = 40711789, upload-time = "2025-04-27T12:29:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/46/1f/7f02009bc7fc8955c391defee5348f510e589a020e4b40ca05edcb847854/pyarrow-20.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:a6ad3e7758ecf559900261a4df985662df54fb7fdb55e8e3b3aa99b23d526b62", size = 42301124, upload-time = "2025-04-27T12:29:17.187Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/92/692c562be4504c262089e86757a9048739fe1acb4024f92d39615e7bab3f/pyarrow-20.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6bb830757103a6cb300a04610e08d9636f0cd223d32f388418ea893a3e655f1c", size = 42916060, upload-time = "2025-04-27T12:29:24.253Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ec/9f5c7e7c828d8e0a3c7ef50ee62eca38a7de2fa6eb1b8fa43685c9414fef/pyarrow-20.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:96e37f0766ecb4514a899d9a3554fadda770fb57ddf42b63d80f14bc20aa7db3", size = 44547640, upload-time = "2025-04-27T12:29:32.782Z" },
+    { url = "https://files.pythonhosted.org/packages/54/96/46613131b4727f10fd2ffa6d0d6f02efcc09a0e7374eff3b5771548aa95b/pyarrow-20.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:3346babb516f4b6fd790da99b98bed9708e3f02e734c84971faccb20736848dc", size = 25781491, upload-time = "2025-04-27T12:29:38.464Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/d6/0c10e0d54f6c13eb464ee9b67a68b8c71bcf2f67760ef5b6fbcddd2ab05f/pyarrow-20.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:75a51a5b0eef32727a247707d4755322cb970be7e935172b6a3a9f9ae98404ba", size = 30815067, upload-time = "2025-04-27T12:29:44.384Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e2/04e9874abe4094a06fd8b0cbb0f1312d8dd7d707f144c2ec1e5e8f452ffa/pyarrow-20.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:211d5e84cecc640c7a3ab900f930aaff5cd2702177e0d562d426fb7c4f737781", size = 32297128, upload-time = "2025-04-27T12:29:52.038Z" },
+    { url = "https://files.pythonhosted.org/packages/31/fd/c565e5dcc906a3b471a83273039cb75cb79aad4a2d4a12f76cc5ae90a4b8/pyarrow-20.0.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ba3cf4182828be7a896cbd232aa8dd6a31bd1f9e32776cc3796c012855e1199", size = 41334890, upload-time = "2025-04-27T12:29:59.452Z" },
+    { url = "https://files.pythonhosted.org/packages/af/a9/3bdd799e2c9b20c1ea6dc6fa8e83f29480a97711cf806e823f808c2316ac/pyarrow-20.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c3a01f313ffe27ac4126f4c2e5ea0f36a5fc6ab51f8726cf41fee4b256680bd", size = 42421775, upload-time = "2025-04-27T12:30:06.875Z" },
+    { url = "https://files.pythonhosted.org/packages/10/f7/da98ccd86354c332f593218101ae56568d5dcedb460e342000bd89c49cc1/pyarrow-20.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:a2791f69ad72addd33510fec7bb14ee06c2a448e06b649e264c094c5b5f7ce28", size = 40687231, upload-time = "2025-04-27T12:30:13.954Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1b/2168d6050e52ff1e6cefc61d600723870bf569cbf41d13db939c8cf97a16/pyarrow-20.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4250e28a22302ce8692d3a0e8ec9d9dde54ec00d237cff4dfa9c1fbf79e472a8", size = 42295639, upload-time = "2025-04-27T12:30:21.949Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/66/2d976c0c7158fd25591c8ca55aee026e6d5745a021915a1835578707feb3/pyarrow-20.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:89e030dc58fc760e4010148e6ff164d2f44441490280ef1e97a542375e41058e", size = 42908549, upload-time = "2025-04-27T12:30:29.551Z" },
+    { url = "https://files.pythonhosted.org/packages/31/a9/dfb999c2fc6911201dcbf348247f9cc382a8990f9ab45c12eabfd7243a38/pyarrow-20.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6102b4864d77102dbbb72965618e204e550135a940c2534711d5ffa787df2a5a", size = 44557216, upload-time = "2025-04-27T12:30:36.977Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8e/9adee63dfa3911be2382fb4d92e4b2e7d82610f9d9f668493bebaa2af50f/pyarrow-20.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:96d6a0a37d9c98be08f5ed6a10831d88d52cac7b13f5287f1e0f625a0de8062b", size = 25660496, upload-time = "2025-04-27T12:30:42.809Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/aa/daa413b81446d20d4dad2944110dcf4cf4f4179ef7f685dd5a6d7570dc8e/pyarrow-20.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:a15532e77b94c61efadde86d10957950392999503b3616b2ffcef7621a002893", size = 30798501, upload-time = "2025-04-27T12:30:48.351Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/75/2303d1caa410925de902d32ac215dc80a7ce7dd8dfe95358c165f2adf107/pyarrow-20.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:dd43f58037443af715f34f1322c782ec463a3c8a94a85fdb2d987ceb5658e061", size = 32277895, upload-time = "2025-04-27T12:30:55.238Z" },
+    { url = "https://files.pythonhosted.org/packages/92/41/fe18c7c0b38b20811b73d1bdd54b1fccba0dab0e51d2048878042d84afa8/pyarrow-20.0.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa0d288143a8585806e3cc7c39566407aab646fb9ece164609dac1cfff45f6ae", size = 41327322, upload-time = "2025-04-27T12:31:05.587Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ab/7dbf3d11db67c72dbf36ae63dcbc9f30b866c153b3a22ef728523943eee6/pyarrow-20.0.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b6953f0114f8d6f3d905d98e987d0924dabce59c3cda380bdfaa25a6201563b4", size = 42411441, upload-time = "2025-04-27T12:31:15.675Z" },
+    { url = "https://files.pythonhosted.org/packages/90/c3/0c7da7b6dac863af75b64e2f827e4742161128c350bfe7955b426484e226/pyarrow-20.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:991f85b48a8a5e839b2128590ce07611fae48a904cae6cab1f089c5955b57eb5", size = 40677027, upload-time = "2025-04-27T12:31:24.631Z" },
+    { url = "https://files.pythonhosted.org/packages/be/27/43a47fa0ff9053ab5203bb3faeec435d43c0d8bfa40179bfd076cdbd4e1c/pyarrow-20.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:97c8dc984ed09cb07d618d57d8d4b67a5100a30c3818c2fb0b04599f0da2de7b", size = 42281473, upload-time = "2025-04-27T12:31:31.311Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/0b/d56c63b078876da81bbb9ba695a596eabee9b085555ed12bf6eb3b7cab0e/pyarrow-20.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9b71daf534f4745818f96c214dbc1e6124d7daf059167330b610fc69b6f3d3e3", size = 42893897, upload-time = "2025-04-27T12:31:39.406Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ac/7d4bd020ba9145f354012838692d48300c1b8fe5634bfda886abcada67ed/pyarrow-20.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e8b88758f9303fa5a83d6c90e176714b2fd3852e776fc2d7e42a22dd6c2fb368", size = 44543847, upload-time = "2025-04-27T12:31:45.997Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/07/290f4abf9ca702c5df7b47739c1b2c83588641ddfa2cc75e34a301d42e55/pyarrow-20.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:30b3051b7975801c1e1d387e17c588d8ab05ced9b1e14eec57915f79869b5031", size = 25653219, upload-time = "2025-04-27T12:31:54.11Z" },
+    { url = "https://files.pythonhosted.org/packages/95/df/720bb17704b10bd69dde086e1400b8eefb8f58df3f8ac9cff6c425bf57f1/pyarrow-20.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:ca151afa4f9b7bc45bcc791eb9a89e90a9eb2772767d0b1e5389609c7d03db63", size = 30853957, upload-time = "2025-04-27T12:31:59.215Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/72/0d5f875efc31baef742ba55a00a25213a19ea64d7176e0fe001c5d8b6e9a/pyarrow-20.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:4680f01ecd86e0dd63e39eb5cd59ef9ff24a9d166db328679e36c108dc993d4c", size = 32247972, upload-time = "2025-04-27T12:32:05.369Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/bc/e48b4fa544d2eea72f7844180eb77f83f2030b84c8dad860f199f94307ed/pyarrow-20.0.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7f4c8534e2ff059765647aa69b75d6543f9fef59e2cd4c6d18015192565d2b70", size = 41256434, upload-time = "2025-04-27T12:32:11.814Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/01/974043a29874aa2cf4f87fb07fd108828fc7362300265a2a64a94965e35b/pyarrow-20.0.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e1f8a47f4b4ae4c69c4d702cfbdfe4d41e18e5c7ef6f1bb1c50918c1e81c57b", size = 42353648, upload-time = "2025-04-27T12:32:20.766Z" },
+    { url = "https://files.pythonhosted.org/packages/68/95/cc0d3634cde9ca69b0e51cbe830d8915ea32dda2157560dda27ff3b3337b/pyarrow-20.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:a1f60dc14658efaa927f8214734f6a01a806d7690be4b3232ba526836d216122", size = 40619853, upload-time = "2025-04-27T12:32:28.1Z" },
+    { url = "https://files.pythonhosted.org/packages/29/c2/3ad40e07e96a3e74e7ed7cc8285aadfa84eb848a798c98ec0ad009eb6bcc/pyarrow-20.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:204a846dca751428991346976b914d6d2a82ae5b8316a6ed99789ebf976551e6", size = 42241743, upload-time = "2025-04-27T12:32:35.792Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/cb/65fa110b483339add6a9bc7b6373614166b14e20375d4daa73483755f830/pyarrow-20.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f3b117b922af5e4c6b9a9115825726cac7d8b1421c37c2b5e24fbacc8930612c", size = 42839441, upload-time = "2025-04-27T12:32:46.64Z" },
+    { url = "https://files.pythonhosted.org/packages/98/7b/f30b1954589243207d7a0fbc9997401044bf9a033eec78f6cb50da3f304a/pyarrow-20.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e724a3fd23ae5b9c010e7be857f4405ed5e679db5c93e66204db1a69f733936a", size = 44503279, upload-time = "2025-04-27T12:32:56.503Z" },
+    { url = "https://files.pythonhosted.org/packages/37/40/ad395740cd641869a13bcf60851296c89624662575621968dcfafabaa7f6/pyarrow-20.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:82f1ee5133bd8f49d31be1299dc07f585136679666b502540db854968576faf9", size = 25944982, upload-time = "2025-04-27T12:33:04.72Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Makes deployment safer by separating fastapi 'public' layer from 'internal' layer while enabling same-machine (i.e. local) working. Also adds basic benchmarking (tests and ci workflow) 